### PR TITLE
(maint) Completely trivial AppVeyor formatting

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 install:
   - git submodule update --init --recursive
 
-  - choco install mingw-w64 -y -Version 4.8.3 -source https://www.myget.org/F/puppetlabs
-  - choco install cmake -Version 3.2.3 -y
+  - choco install -y mingw-w64 -Version 4.8.3 -source https://www.myget.org/F/puppetlabs
+  - choco install -y cmake -Version 3.2.3
   - SET PATH=C:\tools\mingw64\bin;%PATH%
 
   - ps: wget 'https://s3.amazonaws.com/kylo-pl-bucket/boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh.7z' -OutFile "$pwd\boost.7z"


### PR DESCRIPTION
Moves `-y` option so common `choco` options line up.
