### PR TITLE
(maint) Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# How to contribute
+
+Third-party patches are essential for keeping Puppet Labs open-source projects
+great. We want to keep it as easy as possible to contribute changes that
+allow you to get the most out of our projects. There are a few guidelines
+that we need contributors to follow so that we can have a chance of keeping on
+top of things.  For more info, see our canonical guide to contributing:
+
+[https://github.com/puppetlabs/puppet/blob/master/CONTRIBUTING.md](https://github.com/puppetlabs/puppet/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
This commit adds a basic CONTRIBUTING.md,
based on the one used for puppetlabs/trapperkeeper.
