### PR TITLE
(doc) Add steps to push

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This is most simply accomplished with [Hub](https://hub.github.com/). The follow
 hub clone --depth 1 --origin source puppetlabs/cpp-project-template new-project
 cd new-project
 hub create puppetlabs/new-project [-p]
+git commit --amend # Rewrite the commit message, and erase the fact that it's a shallow copy
+git push origin new-project
 ```
 
 Finally update the project() name in CMakeLists.txt.


### PR DESCRIPTION
GitHub prevents pushing shallow copies to a new repo, so add a `commit
--amend` to update the initial commit and erase the fact it's a shallow
copy. Then push the initial commit.
