### PR TITLE
(maint) Split Travis jobs for cpplint/cppcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,13 +25,6 @@ before_install:
   # grab a pre-built cmake 3.2.3
   - wget http://www.cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.tar.gz
   - tar xzvf cmake-3.2.3-Linux-x86_64.tar.gz --strip 1 -C $USERDIR
-  # grab a pre-built cppcheck from s3
-  - wget https://s3.amazonaws.com/kylo-pl-bucket/pcre-8.36_install.tar.bz2
-  - tar xjvf pcre-8.36_install.tar.bz2 --strip 1 -C $USERDIR
-  - wget https://s3.amazonaws.com/kylo-pl-bucket/cppcheck-1.69_install.tar.bz2
-  - tar xjvf cppcheck-1.69_install.tar.bz2 --strip 1 -C $USERDIR
-  # Install coveralls.io update utility
-  - pip install --user cpp-coveralls
 
 script:
   - ./.travis_target.sh
@@ -43,6 +36,8 @@ env:
     - PATH=$USERDIR/bin:$PATH
     - LD_LIBRARY_PATH=$USERDIR/lib:$LD_LIBRARY_PATH
   matrix:
+    - TRAVIS_TARGET=CPPLINT
+    - TRAVIS_TARGET=CPPCHECK
     - TRAVIS_TARGET=RELEASE
     - TRAVIS_TARGET=DEBUG
 

--- a/.travis_target.sh
+++ b/.travis_target.sh
@@ -4,17 +4,39 @@ set -ev
 # Set compiler to GCC 4.8 here, as Travis overrides the global variables.
 export CC=gcc-4.8 CXX=g++-4.8
 
-if [ ${TRAVIS_TARGET} == RELEASE ]; then
-  cmake -Wno-dev .
-  make cpplint
-  make cppcheck
-else
-  cmake -Wno-dev -DCMAKE_BUILD_TYPE=Debug -DCOVERALLS=ON .
+if [ ${TRAVIS_TARGET} == CPPCHECK ]; then
+  # grab a pre-built cppcheck from s3
+  wget https://s3.amazonaws.com/kylo-pl-bucket/pcre-8.36_install.tar.bz2
+  tar xjvf pcre-8.36_install.tar.bz2 --strip 1 -C $USERDIR
+  wget https://s3.amazonaws.com/kylo-pl-bucket/cppcheck-1.69_install.tar.bz2
+  tar xjvf cppcheck-1.69_install.tar.bz2 --strip 1 -C $USERDIR
+elif [ ${TRAVIS_TARGET} == DEBUG ]; then
+  # Install coveralls.io update utility
+  pip install --user cpp-coveralls
 fi
 
-make -j2
-make test ARGS=-V
+# Generate build files
+if [ ${TRAVIS_TARGET} == DEBUG ]; then
+  cmake -DCMAKE_BUILD_TYPE=Debug -DCOVERALLS=ON .
+else
+  cmake .
+fi
 
-# Enable coveralls for public repos
-if [ ${TRAVIS_TARGET} == DEBUG ]; then coveralls --gcov gcov-4.8 --gcov-options '\-lp' -r .. >/dev/null; fi
+if [ ${TRAVIS_TARGET} == CPPLINT ]; then
+  make cpplint
+elif [ ${TRAVIS_TARGET} == CPPCHECK ]; then
+  make cppcheck
+else
+  make -j2
+  make test ARGS=-V
+
+  # Make sure installation succeeds
+  make DESTDIR=$USERDIR install
+
+  # Disable coveralls for private repos
+  if [ ${TRAVIS_TARGET} == DEBUG ]; then
+    # Ignore coveralls failures, keep service success uncoupled
+    coveralls --gcov gcov-4.8 --gcov-options '\-lp' -r .. >/dev/null || true
+  fi
+fi
 


### PR DESCRIPTION
The results of Travis CI jobs are clearer when split based on tasks.
These were originally lumped in because bootstrapping workers was
expensive, but with container-based builds that's no longer the case.

Split out cpplint and cppcheck into their own tasks in Travis CI.
