### PR TITLE
(maint) Use myget mirror for Windows packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ install:
   - git submodule update --init --recursive
 
   - choco install -y mingw-w64 -Version 4.8.3 -source https://www.myget.org/F/puppetlabs
-  - choco install -y cmake -Version 3.2.3
+  - choco install -y cmake -Version 3.2.2 -source https://www.myget.org/F/puppetlabs
   - SET PATH=C:\tools\mingw64\bin;%PATH%
 
   - ps: wget 'https://s3.amazonaws.com/kylo-pl-bucket/boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh.7z' -OutFile "$pwd\boost.7z"


### PR DESCRIPTION
Getting directly from cmake.org has been unreliable recently. Use the
myget mirrored packages.
