### PR TITLE
Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   # Use a predefined install location; cppcheck requires the cfg location is defined at compile-time.
   - mkdir -p $USERDIR
   # grab a pre-built cmake 3.2.3
-  - wget http://www.cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.tar.gz
+  - wget --no-check-certificate https://cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.tar.gz
   - tar xzvf cmake-3.2.3-Linux-x86_64.tar.gz --strip 1 -C $USERDIR
 
 script:

--- a/.travis_target.sh
+++ b/.travis_target.sh
@@ -17,10 +17,9 @@ fi
 
 # Generate build files
 if [ ${TRAVIS_TARGET} == DEBUG ]; then
-  cmake -DCMAKE_BUILD_TYPE=Debug -DCOVERALLS=ON .
-else
-  cmake .
+  TARGET_OPTS="-DCMAKE_BUILD_TYPE=Debug -DCOVERALLS=ON"
 fi
+cmake $TARGET_OPTS -DCMAKE_INSTALL_PREFIX=$USERDIR .
 
 if [ ${TRAVIS_TARGET} == CPPLINT ]; then
   make cpplint
@@ -31,7 +30,7 @@ else
   make test ARGS=-V
 
   # Make sure installation succeeds
-  make DESTDIR=$USERDIR install
+  make install
 
   # Disable coveralls for private repos
   if [ ${TRAVIS_TARGET} == DEBUG ]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,14 +4,13 @@ install:
   - choco install -y mingw-w64 -Version 4.8.3 -source https://www.myget.org/F/puppetlabs
   - choco install -y cmake -Version 3.2.2 -source https://www.myget.org/F/puppetlabs
   - SET PATH=C:\tools\mingw64\bin;%PATH%
+  - ps: $env:PATH = $env:PATH.Replace("Git\bin", "Git\cmd")
 
   - ps: wget 'https://s3.amazonaws.com/kylo-pl-bucket/boost_1_58_0-x86_64_mingw-w64_4.8.3_win32_seh.7z' -OutFile "$pwd\boost.7z"
   - ps: 7z.exe x boost.7z -oC:\tools | FIND /V "ing  "
 
 build_script:
-  - ps: mv "C:\Program Files (x86)\Git\bin\sh.exe" "C:\Program Files (x86)\Git\bin\shxx.exe"
   - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_58_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DBOOST_NOWIDE_SKIP_TESTS=ON -Wno-dev .
-  - ps: mv "C:\Program Files (x86)\Git\bin\shxx.exe" "C:\Program Files (x86)\Git\bin\sh.exe"
   - ps: mingw32-make install
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,12 +5,12 @@ install:
   - choco install -y cmake -Version 3.2.2 -source https://www.myget.org/F/puppetlabs
   - SET PATH=C:\tools\mingw64\bin;%PATH%
 
-  - ps: wget 'https://s3.amazonaws.com/kylo-pl-bucket/boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh.7z' -OutFile "$pwd\boost.7z"
+  - ps: wget 'https://s3.amazonaws.com/kylo-pl-bucket/boost_1_58_0-x86_64_mingw-w64_4.8.3_win32_seh.7z' -OutFile "$pwd\boost.7z"
   - ps: 7z.exe x boost.7z -oC:\tools | FIND /V "ing  "
 
 build_script:
   - ps: mv "C:\Program Files (x86)\Git\bin\sh.exe" "C:\Program Files (x86)\Git\bin\shxx.exe"
-  - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DBOOST_NOWIDE_SKIP_TESTS=ON -Wno-dev .
+  - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_58_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DBOOST_NOWIDE_SKIP_TESTS=ON -Wno-dev .
   - ps: mv "C:\Program Files (x86)\Git\bin\shxx.exe" "C:\Program Files (x86)\Git\bin\sh.exe"
   - ps: mingw32-make
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ build_script:
   - ps: mv "C:\Program Files (x86)\Git\bin\sh.exe" "C:\Program Files (x86)\Git\bin\shxx.exe"
   - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_58_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DBOOST_NOWIDE_SKIP_TESTS=ON -Wno-dev .
   - ps: mv "C:\Program Files (x86)\Git\bin\shxx.exe" "C:\Program Files (x86)\Git\bin\sh.exe"
-  - ps: mingw32-make
+  - ps: mingw32-make install
 
 test_script:
   - ps: ctest -V 2>&1 | %{ if ($_ -is [System.Management.Automation.ErrorRecord]) { $_ | c++filt } else { $_ } }

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -37,10 +37,10 @@ target_link_libraries(lib${PROJECT_NAME}
 # Restricting symbols has several advantages, noted at https://gcc.gnu.org/wiki/Visibility.
 include(GenerateExportHeader)
 generate_export_header(lib${PROJECT_NAME} EXPORT_FILE_NAME "${CMAKE_CURRENT_LIST_DIR}/inc/${PROJECT_NAME}/export.h")
-if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
+if (NOT APPLE)
     add_compiler_export_flags()
-elseif (WIN32)
-    add_compiler_export_flags()
+endif()
+if (WIN32)
     add_definitions("-Dlib${PROJECT_NAME_LOWER}_EXPORTS")
 endif()
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -44,8 +44,11 @@ elseif (WIN32)
     add_definitions("-Dlib${PROJECT_NAME_LOWER}_EXPORTS")
 endif()
 
-get_filename_component(LIBPATH ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} NAME)
-install(TARGETS lib${PROJECT_NAME} DESTINATION ${LIBPATH})
+# This correctly handles DLL installation on Windows.
+install(TARGETS lib${PROJECT_NAME}
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib)
 install(DIRECTORY inc/${PROJECT_NAME} DESTINATION include)
 
 add_subdirectory(tests)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -26,9 +26,9 @@ set(PROJECT_SOURCES "src/${PROJECT_NAME}.cc")
 add_library(libprojectsrc OBJECT ${PROJECT_SOURCES})
 set_target_properties(libprojectsrc PROPERTIES POSITION_INDEPENDENT_CODE true)
 
-add_library(lib${PROJECT_NAME} SHARED $<TARGET_OBJECTS:libprojectsrc>)
-set_target_properties(lib${PROJECT_NAME} PROPERTIES PREFIX "" SUFFIX ".so" IMPORT_PREFIX "" IMPORT_SUFFIX ".so.a" VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
-target_link_libraries(lib${PROJECT_NAME} PRIVATE
+add_library(lib${PROJECT_NAME} $<TARGET_OBJECTS:libprojectsrc>)
+set_target_properties(lib${PROJECT_NAME} PROPERTIES PREFIX "" IMPORT_PREFIX "" VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
+target_link_libraries(lib${PROJECT_NAME}
     ${LEATHERMAN_LIBRARIES}
     ${Boost_LIBRARIES}
 )


### PR DESCRIPTION
##### (maint) Do make install on Windows

```
Test `make install` on Windows. Also configure install location on
Travis via CMake rather than make's DESTDIR (behavior is slightly
different).
```
##### (maint) Allow configuration of static/shared library

```
Consumers building the project should be able to determine whether they
want a static or shared library. Don't hard-code the option, so it can
be configured externally.
```
##### (maint) Let CMake determine correct binary location

```
CMake already knows how to differentiate between runtime, library, and
archive files on Windows. Use the correct install options to do that
rather than hard-coding that dynamic libraries should be installed to
bin (including their import libs, which should be in lib).
```
##### (maint) Bump Leatherman
##### (maint) Use Boost 1.58

```
Internal builds were moved to Boost 1.58, use it for AppVeyor as well.
```
##### (maint) Use visibility on all platforms except Mac

Hides symbols by default and requires explicitly exporting the interface
on all platforms except Apple. On Apple this introduced issues in
Facter, though I don't recall the reason.
