### PR TITLE
(maint) Fix Git in PATH for AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ install:
   - choco install -y cmake -Version 3.2.2 -source https://www.myget.org/F/puppetlabs
   - SET PATH=C:\tools\mingw64\bin;%PATH%
   - ps: $env:PATH = $env:PATH.Replace("Git\bin", "Git\cmd")
+  - ps: $env:PATH = $env:PATH.Replace("Git\usr\bin", "Git\cmd")
 
   - ps: wget 'https://s3.amazonaws.com/kylo-pl-bucket/boost_1_58_0-x86_64_mingw-w64_4.8.3_win32_seh.7z' -OutFile "$pwd\boost.7z"
   - ps: 7z.exe x boost.7z -oC:\tools | FIND /V "ing  "


### PR DESCRIPTION
AppVeyor started using 64-bit Git, which adds `Git\bin` or `Git\usr\bin`
to the PATH (possibly both). Fix them both to use `Git\cmd` instead to
avoid having `sh.exe` in the PATH.
