### PR TITLE
(maint) Coveralls root should point to project root

### DIFF
--- a/.travis_target.sh
+++ b/.travis_target.sh
@@ -44,7 +44,7 @@ else
   # Disable coveralls for private repos
   if [ ${TRAVIS_TARGET} == DEBUG ]; then
     # Ignore coveralls failures, keep service success uncoupled
-    coveralls --gcov gcov-4.8 --gcov-options '\-lp' -r .. >/dev/null || true
+    coveralls --gcov gcov-4.8 --gcov-options '\-lp' >/dev/null || true
   fi
 fi
 


### PR DESCRIPTION
The script to parse coverage data and upload to Coveralls.io was being
pointed to the project's parent directory for parsing. It now uses
the project root, which in this case is the default.
