### PR TITLE
(maint) Standardize command-line options

### DIFF
--- a/exe/driver.cc.in
+++ b/exe/driver.cc.in
@@ -42,6 +42,21 @@ void help(po::options_description& desc)
           "Displays its own version string.", desc) << endl;
 }
 
+void conflicting_options(po::variables_map const& vm, string const& opt1, string const& opt2)
+{
+    if (vm.count(opt1) && !vm[opt1].defaulted() && vm.count(opt2) && !vm[opt2].defaulted()) {
+        throw po::error(opt1 + " and " + opt2 + " options conflict: please specify only one.");
+    }
+}
+
+template<typename... TOpts>
+void conflicting_options(po::variables_map const& vm, string const& opt1, string const& opt2, TOpts && ...opts)
+{
+    conflicting_options(vm, opt1, opt2);
+    conflicting_options(vm, opt1, opts...);
+    conflicting_options(vm, opt2, opts...);
+}
+
 int main(int argc, char **argv) {
     try {
         // Fix args on Windows to be UTF-8
@@ -50,11 +65,20 @@ int main(int argc, char **argv) {
         // Setup logging
         setup_logging(boost::nowide::cerr);
 
+        po::options_description visible_options("");
+        visible_options.add_options()
+            ("debug,d", _("Enable full debugging.").c_str())
+            ("help,h", _("Print this help message.").c_str())
+            ("quiet,q", _("Silences all output.").c_str())
+            ("verbose,V", _("Enable verbosity.").c_str())
+            ("version,v", _("Print the program's version number and exit.").c_str());
+
+        po::options_description hidden_options("");
+        hidden_options.add_options()
+            ("log-level,l", po::value<log_level>()->default_value(log_level::warning, "warn"), _("Set logging level.\nSupported levels are: none, trace, debug, info, warn, error, and fatal.").c_str());
+
         po::options_description command_line_options("");
-        command_line_options.add_options()
-            ("help,h", _("produce help message").c_str())
-            ("log-level,l", po::value<log_level>()->default_value(log_level::warning, "warn"), _("Set logging level.\nSupported levels are: none, trace, debug, info, warn, error, and fatal.").c_str())
-            ("version,v", _("print the version and exit").c_str());
+        command_line_options.add(visible_options).add(hidden_options);
 
         po::variables_map vm;
 
@@ -62,21 +86,30 @@ int main(int argc, char **argv) {
             po::store(po::parse_command_line(argc, argv, command_line_options), vm);
 
             if (vm.count("help")) {
-                help(command_line_options);
+                help(visible_options);
                 return EXIT_SUCCESS;
             }
 
             po::notify(vm);
+
+            conflicting_options(vm, "log-level", "quiet", "verbose", "debug");
         } catch (exception& ex) {
             colorize(boost::nowide::cerr, log_level::error);
-            boost::nowide::cerr << _("error: {1}", ex.what()) << endl;
+            boost::nowide::cerr << _("Error: {1}", ex.what()) << endl;
             colorize(boost::nowide::cerr);
-            help(command_line_options);
+            help(visible_options);
             return EXIT_FAILURE;
         }
 
         // Get the logging level
         auto lvl = vm["log-level"].as<log_level>();
+        if (vm.count("debug")) {
+            lvl = log_level::debug;
+        } else if (vm.count("verbose")) {
+            lvl = log_level::info;
+        } else if (vm.count("quiet")) {
+            lvl = log_level::none;
+        }
         set_level(lvl);
 
         if (vm.count("version")) {

--- a/locales/cpp-project-template.pot
+++ b/locales/cpp-project-template.pot
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Puppet <docs@puppet.com>
-# This file is distributed under the same license as the PACKAGE package.
+# This file is distributed under the same license as the cpp-project-template package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
@@ -40,7 +40,23 @@ msgid ""
 msgstr ""
 
 #: exe/cpp-project-template.cc
-msgid "produce help message"
+msgid "Enable full debugging."
+msgstr ""
+
+#: exe/cpp-project-template.cc
+msgid "Print this help message."
+msgstr ""
+
+#: exe/cpp-project-template.cc
+msgid "Silences all output."
+msgstr ""
+
+#: exe/cpp-project-template.cc
+msgid "Enable verbosity."
+msgstr ""
+
+#: exe/cpp-project-template.cc
+msgid "Print the program's version number and exit."
 msgstr ""
 
 #: exe/cpp-project-template.cc
@@ -50,11 +66,7 @@ msgid ""
 msgstr ""
 
 #: exe/cpp-project-template.cc
-msgid "print the version and exit"
-msgstr ""
-
-#: exe/cpp-project-template.cc
-msgid "error: {1}"
+msgid "Error: {1}"
 msgstr ""
 
 #: exe/cpp-project-template.cc

--- a/locales/fr.po
+++ b/locales/fr.po
@@ -8,14 +8,14 @@ msgstr ""
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: 2016-07-31 20:25-0700\n"
+"Last-Translator: \n"
 "Language-Team: \n"
+"Language: fr_FR.utf8\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.8\n"
-"Last-Translator: \n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"Language: fr_FR.utf8\n"
 
 #: exe/cpp-project-template.cc
 msgid ""
@@ -58,8 +58,24 @@ msgstr ""
 "Affiche sa propre chaîne de version."
 
 #: exe/cpp-project-template.cc
-msgid "produce help message"
-msgstr "produire le message d’aide"
+msgid "Enable full debugging."
+msgstr "Activer le débogage complet."
+
+#: exe/cpp-project-template.cc
+msgid "Print this help message."
+msgstr "Produire le message d’aide"
+
+#: exe/cpp-project-template.cc
+msgid "Silences all output."
+msgstr "Silences toutes les sorties."
+
+#: exe/cpp-project-template.cc
+msgid "Enable verbosity."
+msgstr "Activer verbosité."
+
+#: exe/cpp-project-template.cc
+msgid "Print the program's version number and exit."
+msgstr "Imprimer la version de make API de et sortir."
 
 #: exe/cpp-project-template.cc
 msgid ""
@@ -67,15 +83,12 @@ msgid ""
 "Supported levels are: none, trace, debug, info, warn, error, and fatal."
 msgstr ""
 "Réglez le niveau d’enregistrement.\n"
-"Niveaux de prises en charge sont : aucun, trace, debug, info, warn, error et fatal."
+"Niveaux de prises en charge sont : aucun, trace, debug, info, warn, error et "
+"fatal."
 
 #: exe/cpp-project-template.cc
-msgid "print the version and exit"
-msgstr "Imprimer la version de make API de et sortir."
-
-#: exe/cpp-project-template.cc
-msgid "error: {1}"
-msgstr "erreur: {1}"
+msgid "Error: {1}"
+msgstr "Erreur: {1}"
 
 #: exe/cpp-project-template.cc
 msgid "unhandled exception: {1}"


### PR DESCRIPTION
Bring command-line options inline with UX guidelines.
Resolves #23.
