### PR TITLE
(maint) Make build folder regexes more general

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,10 +14,10 @@ Gemfile.lock
 /lib/Doxyfile
 /lib/html/
 /lib/docs/
-/debug*/
-/release*/
+/*debug*/
+/*release*/
 /.idea/
-/build/
+/*build*/
 acceptance/.bundle/
 acceptance/vendor/
 acceptance/junit/


### PR DESCRIPTION
This is useful when building on VMs with shared folders enabled, because it makes Git ignore build directories named things like `linux-build`.
