### PR TITLE
Remove clang-tidy, use new cppcheck (Docker image v3)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,23 +1,20 @@
-# Build clang-tidy; this takes awhile and is memory-constrained (requires 4GB).
+# Build a newer version of cppcheck (because it's been buggy)
 FROM alpine:3.6
-WORKDIR /usr/src/llvm
-RUN apk add --no-cache alpine-sdk cmake curl util-linux-dev ninja python zlib && \
-    curl -OL https://github.com/llvm-project/llvm-project-20170507/archive/release_50.zip && \
-    unzip release_50.zip && \
-    cmake ./llvm-project-20170507-release_50/llvm -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra" \
-          -GNinja -DCMAKE_BUILD_TYPE=MinSizeRel -DLLVM_TARGETS_TO_BUILD=X86 && \
-    ninja -j4 clang-tidy clang-apply-replacements
+RUN apk add --no-cache alpine-sdk cmake util-linux-dev ninja python zlib pcre-dev && \
+    wget https://github.com/danmar/cppcheck/archive/1.87.tar.gz && \
+    tar xzvf 1.87.tar.gz && \
+    cd cppcheck-1.87 && \
+    make install -j4 DESTDIR=/dest SRCDIR=build CFGDIR=/usr/share/cppcheck/cfg HAVE_RULES=yes CXXFLAGS="-O2 -DNDEBUG"
 
 
 FROM alpine:3.6
 LABEL author="Michael Smith \"michael.smith@puppet.com\""
 LABEL description="A C++ build container"
 
-COPY --from=0 /usr/src/llvm/bin/clang-tidy /usr/bin
-COPY --from=0 /usr/src/llvm/bin/clang-apply-replacements /usr/bin
+COPY --from=0 /dest /
 
 # Uses sed to patch https://svn.boost.org/trac10/ticket/12419
-RUN apk add --no-cache bash alpine-sdk cmake cppcheck doxygen boost-dev yaml-cpp-dev openssl-dev \
+RUN apk add --no-cache bash alpine-sdk cmake doxygen boost-dev yaml-cpp-dev openssl-dev \
                        curl-dev icu-dev util-linux-dev ruby ruby-irb ruby-json valgrind gettext \
                        python2-dev py2-pip libffi-dev && \
     sed -i -e 's/sys\/poll/poll/' /usr/include/boost/asio/detail/socket_types.hpp && \


### PR DESCRIPTION
clang-tidy never got used in practice and the version being built was out-of-date. Remove it because it's very slow to build.

Use a newer version of cppcheck because we're running into a bug handling raw strings in pxp-agent.